### PR TITLE
fix exception of `ceph-deploy osd list HOST`

### DIFF
--- a/ceph_deploy/osd.py
+++ b/ceph_deploy/osd.py
@@ -494,6 +494,9 @@ def osd_list(args, cfg):
         remote_module = distro.conn.remote_module
         osds = distro.conn.remote_module.listdir(constants.osd_path)
 
+        osd_id = r'{cluster}-(\d+)'.format(cluster=args.cluster)
+        osds = filter(lambda osd: re.match(osd_id, osd), osds)
+
         ceph_disk_executable = system.executable_path(distro.conn, 'ceph-disk')
         output, err, exit_code = remoto.process.check(
             distro.conn,


### PR DESCRIPTION
If we make a dir(NO {cluster-name}-N) in /var/lib/ceph/osd/,
`ceph-deploy osd list HOST` will occur an exception when getting
osd id.